### PR TITLE
Bump log4j to version 2.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.boot.version>2.4.0</spring.boot.version>
 		<groovy.version>3.0.7</groovy.version>
-		<log4j2.version>2.15.0</log4j2.version>
+		<log4j2.version>2.20.0</log4j2.version>
 		<scm.base>scm:git:git@github.com:unity-idm/users-deprovisioning.git</scm.base>
 	</properties>
 


### PR DESCRIPTION
Since used log4j was vulnerable, we updated the used version.